### PR TITLE
Corrige promises de publicação

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,13 +79,13 @@ const WorkerFactory = (connectUrl, opts = {}) => {
 
           emitter.emit("log", "debug", name, "publishing", message)
 
-          ch.close()
+          yield ch.close()
 
           return true
 
         } catch(err) {
 
-          ch.close()
+          yield ch.close()
           throw err
         }
       })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resilient-consumer",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "resilient consumer prof",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
O código da publicação não estava esperando o channel fechar, e por algum motivo a promise resolvia mesmo assim.
Adicionei o `yield` nos `ch.close()`.